### PR TITLE
Send the channel process instead of the channel id

### DIFF
--- a/src/enet_channel.erl
+++ b/src/enet_channel.erl
@@ -109,7 +109,7 @@ loop(S = #state{ id = ID, peer = Peer, owner = Owner }) ->
            #command_header{ unsequenced = 1 },
            C = #unsequenced{}
           }} ->
-            Owner ! {enet, ID, C},
+            Owner ! {enet, self(), C},
             loop(S);
         {send_unsequenced, Data} ->
             {H, C} = enet_command:send_unsequenced(ID, Data),
@@ -124,7 +124,7 @@ loop(S = #state{ id = ID, peer = Peer, owner = Owner }) ->
                     %% Data is old - drop it and continue.
                     loop(S);
                true ->
-                    Owner ! {enet, ID, C},
+                    Owner ! {enet, self(), C},
                     NewS = S#state{ incoming_unreliable_sequence_number = N },
                     loop(NewS)
             end;
@@ -139,7 +139,7 @@ loop(S = #state{ id = ID, peer = Peer, owner = Owner }) ->
            #command_header{ reliable_sequence_number = N },
            C = #reliable{}
           }} when N =:= S#state.incoming_reliable_sequence_number ->
-            Owner ! {enet, ID, C},
+            Owner ! {enet, self(), C},
             NewS = S#state{ incoming_reliable_sequence_number = N + 1 },
             loop(NewS);
         {send_reliable, Data} ->

--- a/src/enet_tests.erl
+++ b/src/enet_tests.erl
@@ -125,12 +125,16 @@ unsequenced_messages_test() ->
     ok = enet:send_unsequenced(LocalChannel1, <<"local->remote">>),
     ok = enet:send_unsequenced(RemoteChannel1, <<"remote->local">>),
     receive
-        {enet, 0, #unsequenced{ data = <<"local->remote">> }} -> ok
+        {enet, ChannelWhichShouldBeRemote, #unsequenced{ data = <<"local->remote">> }
+        } when ChannelWhichShouldBeRemote =:= RemoteChannel1 ->
+            ok
     after 500 ->
             exit(remote_channel_did_not_send_data_to_owner)
     end,
     receive
-        {enet, 0, #unsequenced{ data = <<"remote->local">> }} -> ok
+        {enet, ChannelWhichShouldBeLocal, #unsequenced{ data = <<"remote->local">> }
+        } when ChannelWhichShouldBeLocal =:= LocalChannel1 ->
+            ok
     after 500 ->
             exit(local_channel_did_not_send_data_to_owner)
     end,
@@ -156,22 +160,30 @@ unreliable_messages_test() ->
     ok = enet:send_unreliable(LocalChannel1, <<"local->remote 2">>),
     ok = enet:send_unreliable(RemoteChannel1, <<"remote->local 2">>),
     receive
-        {enet, 0, #unreliable{ data = <<"local->remote 1">> }} -> ok
+        {enet, ChannelWhichShouldBeRemote1, #unreliable{ data = <<"local->remote 1">> }
+        } when ChannelWhichShouldBeRemote1 =:= RemoteChannel1 ->
+            ok
     after 500 ->
             exit(remote_channel_did_not_send_data_to_owner)
     end,
     receive
-        {enet, 0, #unreliable{ data = <<"remote->local 1">> }} -> ok
+        {enet, ChannelWhichShouldBeLocal1, #unreliable{ data = <<"remote->local 1">> }
+        } when ChannelWhichShouldBeLocal1 =:= LocalChannel1 ->
+            ok
     after 500 ->
             exit(local_channel_did_not_send_data_to_owner)
     end,
     receive
-        {enet, 0, #unreliable{ data = <<"local->remote 2">> }} -> ok
+        {enet, ChannelWhichShouldBeRemote2, #unreliable{ data = <<"local->remote 2">> }
+        } when ChannelWhichShouldBeRemote2 =:= RemoteChannel1 ->
+            ok
     after 500 ->
             exit(remote_channel_did_not_send_data_to_owner)
     end,
     receive
-        {enet, 0, #unreliable{ data = <<"remote->local 2">> }} -> ok
+        {enet, ChannelWhichShouldBeLocal2, #unreliable{ data = <<"remote->local 2">> }
+        } when ChannelWhichShouldBeLocal2 =:= LocalChannel1 ->
+            ok
     after 500 ->
             exit(local_channel_did_not_send_data_to_owner)
     end,
@@ -197,22 +209,30 @@ reliable_messages_test() ->
     ok = enet:send_reliable(LocalChannel1, <<"local->remote 2">>),
     ok = enet:send_reliable(RemoteChannel1, <<"remote->local 2">>),
     receive
-        {enet, 0, #reliable{ data = <<"local->remote 1">> }} -> ok
+        {enet, ChannelWhichShouldBeRemote1, #reliable{ data = <<"local->remote 1">> }
+        } when ChannelWhichShouldBeRemote1 =:= RemoteChannel1 ->
+            ok
     after 500 ->
             exit(remote_channel_did_not_send_data_to_owner)
     end,
     receive
-        {enet, 0, #reliable{ data = <<"remote->local 1">> }} -> ok
+        {enet, ChannelWhichShouldBeLocal1, #reliable{ data = <<"remote->local 1">> }
+        } when ChannelWhichShouldBeLocal1 =:= LocalChannel1 ->
+            ok
     after 500 ->
             exit(local_channel_did_not_send_data_to_owner)
     end,
     receive
-        {enet, 0, #reliable{ data = <<"local->remote 2">> }} -> ok
+        {enet, ChannelWhichShouldBeRemote2, #reliable{ data = <<"local->remote 2">> }
+        } when ChannelWhichShouldBeRemote2 =:= RemoteChannel1 ->
+            ok
     after 500 ->
             exit(remote_channel_did_not_send_data_to_owner)
     end,
     receive
-        {enet, 0, #reliable{ data = <<"remote->local 2">> }} -> ok
+        {enet, ChannelWhichShouldBeLocal2, #reliable{ data = <<"remote->local 2">> }
+        } when ChannelWhichShouldBeLocal2 =:= LocalChannel1 ->
+            ok
     after 500 ->
             exit(local_channel_did_not_send_data_to_owner)
     end,

--- a/test/enet_sync.erl
+++ b/test/enet_sync.erl
@@ -93,7 +93,7 @@ send_unsequenced(Channel, Data) ->
 send_unreliable(Channel, Data) ->
     enet:send_unreliable(Channel, Data),
     receive
-        {enet, _ID, #unreliable{ data = Data }} ->
+        {enet, _Channel, #unreliable{ data = Data }} ->
             ok
     after 1000 ->
             {error, data_not_received}
@@ -102,7 +102,7 @@ send_unreliable(Channel, Data) ->
 send_reliable(Channel, Data) ->
     enet:send_reliable(Channel, Data),
     receive
-        {enet, _ID, #reliable{ data = Data }} ->
+        {enet, _Channel, #reliable{ data = Data }} ->
             ok
     after 1000 ->
             {error, data_not_received}


### PR DESCRIPTION
If I want to be able to respond to a message I usually need the channel
process, not the id. If I really need the id, I can get it from the info
which I received during the connect. The other way round, one cannot get
the right channel based on the channel id alone, since the channel id
may be the same for multiple peers.

Closes #6