### PR TITLE
Fixed typespecs (iolist() -> iodata())

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Disconnect `Peer` immediately without waiting for an ACK from the remote peer.
 send_unsequenced(Channel, Data) -> ok
 
     Channel = pid()
-    Data = iolist()
+    Data = iodata()
 ```
 Send *unsequenced* data to the remote peer over `Channel`.
 
@@ -88,7 +88,7 @@ Send *unsequenced* data to the remote peer over `Channel`.
 send_unreliable(Channel, Data) -> ok
 
     Channel = pid()
-    Data = iolist()
+    Data = iodata()
 ```
 Send *unreliable* data to the remote peer over `Channel`.
 
@@ -97,7 +97,7 @@ Send *unreliable* data to the remote peer over `Channel`.
 send_reliable(Channel, Data) -> ok
 
     Channel = pid()
-    Data = iolist()
+    Data = iodata()
 ```
 Send *reliable* data to the remote peer over `Channel`.
 
@@ -107,7 +107,7 @@ broadcast_unsequenced(HostPort, ChannelID, Data) -> ok
 
     HostPort = port_number()
     ChannelID = integer()
-    Data = iolist()
+    Data = iodata()
 ```
 Broadcast *unsequenced* data to all peers connected to `HostPort` on `ChannelID`.
 
@@ -117,7 +117,7 @@ broadcast_unreliable(HostPort, ChannelID, Data) -> ok
 
     HostPort = port_number()
     ChannelID = integer()
-    Data = iolist()
+    Data = iodata()
 ```
 Broadcast *unreliable* data to all peers connected to `HostPort` on `ChannelID`.
 
@@ -127,7 +127,7 @@ broadcast_reliable(HostPort, ChannelID, Data) -> ok
 
     HostPort = port_number()
     ChannelID = integer()
-    Data = iolist()
+    Data = iodata()
 ```
 Broadcast *reliable* data to all peers connected to `HostPort` on `ChannelID`.
 

--- a/src/enet.erl
+++ b/src/enet.erl
@@ -76,19 +76,19 @@ disconnect_peer_now(Peer) ->
     enet_peer:disconnect_now(Peer).
 
 
--spec send_unsequenced(Channel :: pid(), Data :: iolist()) -> ok.
+-spec send_unsequenced(Channel :: pid(), Data :: iodata()) -> ok.
 
 send_unsequenced(Channel, Data) ->
     enet_channel:send_unsequenced(Channel, Data).
 
 
--spec send_unreliable(Channel :: pid(), Data :: iolist()) -> ok.
+-spec send_unreliable(Channel :: pid(), Data :: iodata()) -> ok.
 
 send_unreliable(Channel, Data) ->
     enet_channel:send_unreliable(Channel, Data).
 
 
--spec send_reliable(Channel :: pid(), Data :: iolist()) -> ok.
+-spec send_reliable(Channel :: pid(), Data :: iodata()) -> ok.
 
 send_reliable(Channel, Data) ->
     enet_channel:send_reliable(Channel, Data).
@@ -96,7 +96,7 @@ send_reliable(Channel, Data) ->
 
 -spec broadcast_unsequenced(HostPort :: port_number(),
                             ChannelID :: integer(),
-                            Data :: iolist()) -> ok.
+                            Data :: iodata()) -> ok.
 
 broadcast_unsequenced(HostPort, ChannelID, Data) ->
     broadcast(HostPort, ChannelID, Data, fun send_unsequenced/2).
@@ -104,7 +104,7 @@ broadcast_unsequenced(HostPort, ChannelID, Data) ->
 
 -spec broadcast_unreliable(HostPort :: port_number(),
                            ChannelID :: integer(),
-                           Data :: iolist()) -> ok.
+                           Data :: iodata()) -> ok.
 
 broadcast_unreliable(HostPort, ChannelID, Data) ->
     broadcast(HostPort, ChannelID, Data, fun send_unreliable/2).
@@ -112,7 +112,7 @@ broadcast_unreliable(HostPort, ChannelID, Data) ->
 
 -spec broadcast_reliable(HostPort :: port_number(),
                          ChannelID :: integer(),
-                         Data :: iolist()) -> ok.
+                         Data :: iodata()) -> ok.
 
 broadcast_reliable(HostPort, ChannelID, Data) ->
     broadcast(HostPort, ChannelID, Data, fun send_reliable/2).


### PR DESCRIPTION
`iodata()` is `iolist() | iodata()`
`iolist()` only is a list of `iodata()`